### PR TITLE
fix: stop returning internal error details to API callers

### DIFF
--- a/server/api.test.js
+++ b/server/api.test.js
@@ -3,10 +3,19 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 // Mock the chat engine — the external AI boundary
 const mockChat = vi.fn();
 const mockResetSession = vi.fn();
+const mockStartOAuthFlow = vi.fn();
+const mockGetOAuthStatus = vi.fn();
+const mockCleanupOAuthSessions = vi.fn();
 
 vi.mock('./ai/chat-engine.js', () => ({
   chat: (...args) => mockChat(...args),
   resetSession: (...args) => mockResetSession(...args),
+}));
+
+vi.mock('./ai/claude-oauth.js', () => ({
+  startOAuthFlow: (...args) => mockStartOAuthFlow(...args),
+  getOAuthStatus: (...args) => mockGetOAuthStatus(...args),
+  cleanupOAuthSessions: (...args) => mockCleanupOAuthSessions(...args),
 }));
 
 // Import app after mocks are set up
@@ -18,6 +27,18 @@ let baseUrl;
 beforeEach(async () => {
   mockChat.mockReset();
   mockResetSession.mockReset();
+  mockStartOAuthFlow.mockReset();
+  mockGetOAuthStatus.mockReset();
+  mockCleanupOAuthSessions.mockReset();
+
+  mockStartOAuthFlow.mockResolvedValue({
+    state: 'oauth-state',
+    oauthUrl: 'https://example.com/oauth',
+  });
+  mockGetOAuthStatus.mockReturnValue({
+    status: 'pending',
+    error: null,
+  });
 
   // Start a test server on a random port
   await new Promise((resolve) => {
@@ -54,6 +75,19 @@ describe('GET /api/health', () => {
 });
 
 // --- Chat endpoint ---
+
+describe('POST /api/auth/start', () => {
+  it('returns a generic error when oauth startup fails', async () => {
+    mockStartOAuthFlow.mockRejectedValueOnce(new Error('OAuth port binding failed'));
+
+    const { status, data } = await request('POST', '/api/auth/start');
+
+    expect(status).toBe(500);
+    expect(data.ok).toBe(false);
+    expect(data.error).toBe('Could not start Claude sign-in.');
+    expect(data.error).not.toContain('OAuth port binding failed');
+  });
+});
 
 describe('POST /api/chat', () => {
   it('returns reply and action from chat engine', async () => {
@@ -189,6 +223,7 @@ describe('POST /api/chat', () => {
 
     expect(status).toBe(500);
     expect(data.error).toBe('Failed to process chat message');
+    expect(data.detail).toBeUndefined();
     expect(data.reply).toBeDefined();
     expect(data.action).toBeNull();
   });

--- a/server/app.js
+++ b/server/app.js
@@ -115,9 +115,13 @@ app.post('/api/auth/start', async (req, res) => {
     const result = await startOAuthFlow();
     res.json({ ok: true, state: result.state, oauthUrl: result.oauthUrl });
   } catch (err) {
+    console.error('  [auth start error]', err instanceof Error ? err.message : err);
+    if (err instanceof Error && err.stack) {
+      console.error('  [auth start stack]', err.stack);
+    }
     res.status(500).json({
       ok: false,
-      error: err instanceof Error ? err.message : 'Could not start Claude sign-in.',
+      error: 'Could not start Claude sign-in.',
     });
   }
 });
@@ -157,7 +161,6 @@ app.post('/api/chat', async (req, res) => {
     console.error('  [chat stack]', err.stack);
     res.status(500).json({
       error: 'Failed to process chat message',
-      detail: err.message,
       reply: 'Something went wrong on my end. Please try again.',
       action: null,
     });


### PR DESCRIPTION
## Summary
- `/api/auth/start`: always returns generic error message instead of leaking `err.message`
- `/api/chat`: removes `detail` field that exposed internal error text
- Both endpoints log full error details server-side only
- Adds new test for auth/start error sanitization
- Strengthens existing chat error test to assert `detail` is absent

## Test plan
- [x] `npm test -- server/api.test.js` — 17 tests pass
- [ ] Manual: trigger auth failure, verify response has no internal details

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)