### PR TITLE
fix: harden Claude OAuth credential file permissions

### DIFF
--- a/server/ai/claude-oauth.js
+++ b/server/ai/claude-oauth.js
@@ -68,7 +68,7 @@ async function writeClaudeCredentials(tokenJson) {
   const configDir = claudeConfigDir();
   const filePath = credentialsPath();
 
-  await fs.mkdir(configDir, { recursive: true });
+  await fs.mkdir(configDir, { recursive: true, mode: 0o700 });
 
   let existing = {};
   try {
@@ -99,7 +99,7 @@ async function writeClaudeCredentials(tokenJson) {
       : null,
   };
 
-  await fs.writeFile(filePath, JSON.stringify(existing, null, 2), 'utf8');
+  await fs.writeFile(filePath, JSON.stringify(existing, null, 2), { encoding: 'utf8', mode: 0o600 });
 }
 
 function buildAuthorizeUrl(port, challenge, state) {
@@ -352,4 +352,5 @@ export {
   startOAuthFlow,
   getOAuthStatus,
   cleanupOAuthSessions,
+  writeClaudeCredentials,
 };

--- a/server/ai/claude-oauth.test.js
+++ b/server/ai/claude-oauth.test.js
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockMkdir = vi.fn().mockResolvedValue(undefined);
+const mockReadFile = vi.fn().mockResolvedValue('{}');
+const mockWriteFile = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('fs', () => ({
+  promises: {
+    mkdir: (...args) => mockMkdir(...args),
+    readFile: (...args) => mockReadFile(...args),
+    writeFile: (...args) => mockWriteFile(...args),
+  },
+}));
+
+import { writeClaudeCredentials } from './claude-oauth.js';
+
+describe('writeClaudeCredentials', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockMkdir.mockResolvedValue(undefined);
+    mockReadFile.mockResolvedValue('{}');
+    mockWriteFile.mockResolvedValue(undefined);
+  });
+
+  it('creates config directory with mode 0o700', async () => {
+    await writeClaudeCredentials({
+      access_token: 'tok_test',
+      refresh_token: 'ref_test',
+      expires_in: 3600,
+      scope: 'user:inference',
+    });
+
+    expect(mockMkdir).toHaveBeenCalledTimes(1);
+    expect(mockMkdir).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ recursive: true, mode: 0o700 })
+    );
+  });
+
+  it('writes credentials file with mode 0o600', async () => {
+    await writeClaudeCredentials({
+      access_token: 'tok_test',
+      refresh_token: 'ref_test',
+      expires_in: 3600,
+      scope: 'user:inference',
+    });
+
+    expect(mockWriteFile).toHaveBeenCalledTimes(1);
+    expect(mockWriteFile).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.objectContaining({ encoding: 'utf8', mode: 0o600 })
+    );
+  });
+
+  it('writes valid JSON with claudeAiOauth structure', async () => {
+    await writeClaudeCredentials({
+      access_token: 'tok_test',
+      refresh_token: 'ref_test',
+      expires_in: 3600,
+      scope: 'user:inference',
+    });
+
+    const writtenJson = JSON.parse(mockWriteFile.mock.calls[0][1]);
+    expect(writtenJson.claudeAiOauth).toBeDefined();
+    expect(writtenJson.claudeAiOauth.accessToken).toBe('tok_test');
+    expect(writtenJson.claudeAiOauth.refreshToken).toBe('ref_test');
+    expect(writtenJson.claudeAiOauth.scopes).toEqual(['user:inference']);
+  });
+});


### PR DESCRIPTION
## Summary
- Config directory (`~/.claude/`) created with mode `0o700` (owner-only)
- Credentials file (`.credentials.json`) written with mode `0o600` (owner read/write)
- Prevents other users on shared systems from reading OAuth tokens
- Adds 3 unit tests verifying restrictive file modes

## Test plan
- [x] `npm test -- server/ai/claude-oauth.test.js` — 3 tests pass
- [ ] Manual: run OAuth flow, verify `ls -la ~/.claude/.credentials.json` shows `-rw-------`

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)