### PR TITLE
fix: bind non-Electron servers to 127.0.0.1 by default

### DIFF
--- a/bin/deckwing.js
+++ b/bin/deckwing.js
@@ -71,8 +71,10 @@ app.get('*', (req, res) => {
 // Stale session cleanup
 setInterval(cleanStaleSessions, 15 * 60 * 1000);
 
+const HOST = process.env.HOST || '127.0.0.1';
+
 function tryListen(port, maxRetries = 5) {
-  const server = app.listen(port, () => {
+  const server = app.listen(port, HOST, () => {
     const url = `http://localhost:${port}`;
     console.log('');
     console.log('  🐔 DeckWing is ready!');

--- a/server/index.js
+++ b/server/index.js
@@ -9,6 +9,8 @@ const PORT = process.env.PORT || 3001;
 // Purge stale sessions every 15 minutes
 setInterval(cleanStaleSessions, 15 * 60 * 1000);
 
-app.listen(PORT, () => {
+const HOST = process.env.HOST || '127.0.0.1';
+
+app.listen(PORT, HOST, () => {
   // Server started (bin/deckwing.js shows the user-facing message)
 });


### PR DESCRIPTION
## Summary
- `server/index.js` and `bin/deckwing.js` now explicitly bind to `127.0.0.1`
- Supports `HOST=0.0.0.0` env override for advanced dev use
- Aligns all runtimes with the safer behavior already used by Electron

## Test plan
- [x] `npm test` — 275 tests pass
- [ ] Manual: `npm run server`, verify listening on `127.0.0.1:3001` not `0.0.0.0:3001`
- [ ] Manual: `deckwing` CLI, verify same

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)