### PR TITLE
fix: restrict CORS to localhost origins only

### DIFF
--- a/server/api.test.js
+++ b/server/api.test.js
@@ -32,14 +32,22 @@ afterEach(async () => {
   await new Promise((resolve) => server.close(resolve));
 });
 
-async function request(method, path, body) {
+async function request(method, path, body, options = {}) {
+  const { headers: extraHeaders = {} } = options;
   const res = await fetch(`${baseUrl}${path}`, {
     method,
-    headers: body ? { 'Content-Type': 'application/json' } : {},
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...extraHeaders,
+    },
     body: body ? JSON.stringify(body) : undefined,
   });
-  const data = await res.json();
-  return { status: res.status, data };
+  const contentType = res.headers.get('content-type') ?? '';
+  const data = contentType.includes('application/json')
+    ? await res.json()
+    : await res.text();
+
+  return { status: res.status, headers: res.headers, data };
 }
 
 // --- Health check ---
@@ -50,6 +58,40 @@ describe('GET /api/health', () => {
     expect(status).toBe(200);
     expect(data.status).toBe('ok');
     expect(data.service).toBe('deckwing');
+  });
+});
+
+describe('CORS', () => {
+  it('allows requests without an Origin header', async () => {
+    const { status, data, headers } = await request('GET', '/api/health');
+
+    expect(status).toBe(200);
+    expect(data.status).toBe('ok');
+    expect(headers.get('access-control-allow-origin')).toBeNull();
+  });
+
+  it('allows requests from http://localhost:3000', async () => {
+    const { status, headers } = await request('GET', '/api/health', undefined, {
+      headers: { Origin: 'http://localhost:3000' },
+    });
+
+    expect(status).toBe(200);
+    expect(headers.get('access-control-allow-origin')).toBe('http://localhost:3000');
+  });
+
+  it('blocks requests from disallowed origins', async () => {
+    const { status, data, headers } = await request('GET', '/api/health', undefined, {
+      headers: { Origin: 'http://evil.com' },
+    });
+
+    expect(status).toBeGreaterThanOrEqual(400);
+    expect(headers.get('access-control-allow-origin')).toBeNull();
+
+    if (typeof data === 'string') {
+      expect(data).toContain('CORS: origin not allowed');
+    } else {
+      expect(data.error).toContain('CORS');
+    }
   });
 });
 

--- a/server/app.js
+++ b/server/app.js
@@ -11,10 +11,24 @@ import { startOAuthFlow, getOAuthStatus, cleanupOAuthSessions } from './ai/claud
 import { findClaudeBinary, checkClaudeVersion } from './ai/find-claude.js';
 
 const execFileAsync = promisify(execFile);
+const ALLOWED_ORIGINS = new Set([
+  'http://localhost:3000',
+  'http://127.0.0.1:3000',
+  'http://localhost:3001',
+  'http://127.0.0.1:3001',
+]);
 
 const app = express();
 
-app.use(cors());
+app.use(cors({
+  origin(origin, callback) {
+    if (!origin || ALLOWED_ORIGINS.has(origin)) {
+      callback(null, true);
+    } else {
+      callback(new Error('CORS: origin not allowed'));
+    }
+  },
+}));
 app.use(express.json({ limit: '10mb' }));
 
 /**
@@ -192,6 +206,14 @@ app.post('/api/deck/review', (req, res) => {
 app.get('/api/decks', (req, res) => {
   // TODO: Implement deck persistence
   res.json({ decks: [] });
+});
+
+app.use((err, req, res, next) => {
+  if (err?.message === 'CORS: origin not allowed') {
+    return res.status(403).json({ error: err.message });
+  }
+
+  return next(err);
 });
 
 export default app;


### PR DESCRIPTION
## Summary
- Replaces open `app.use(cors())` with allowlist: `localhost:3000`, `localhost:3001`, `127.0.0.1` variants
- Same-origin (no Origin header, Electron) still works
- External origins get `403 { error: "CORS: origin not allowed" }`
- Adds 3 CORS tests: no-origin allowed, localhost allowed, external blocked

## Test plan
- [x] `npm test -- server/api.test.js` — 19 tests pass
- [ ] Manual: browser at localhost:3000, verify API calls work
- [ ] Manual: open browser console on external site, verify fetch to localhost:3001 fails

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)