### PR TITLE
fix: stop logging OAuth callback query data and sensitive details

### DIFF
--- a/server/ai/claude-oauth.js
+++ b/server/ai/claude-oauth.js
@@ -160,8 +160,7 @@ async function exchangeAuthorizationCode(session, code, returnedState) {
   });
 
   if (!response.ok) {
-    const body = await response.text();
-    throw new Error(`Token exchange failed (${response.status}): ${body || response.statusText}`);
+    throw new Error(`Token exchange failed (${response.status})`);
   }
 
   return response.json();
@@ -174,7 +173,7 @@ function createCallbackServer(state) {
   }
 
   const server = http.createServer(async (req, res) => {
-    console.log(`  [oauth] Callback received: ${req.url}`);
+    console.log('  [oauth] Callback received');
     const requestUrl = new URL(req.url || '/', `http://${CALLBACK_HOST}`);
 
     if (requestUrl.pathname !== CALLBACK_PATH) {
@@ -229,14 +228,13 @@ function createCallbackServer(state) {
       res.writeHead(302, { Location: SUCCESS_URL });
       res.end();
     } catch (err) {
-      const errMsg = err instanceof Error ? err.message : 'Token exchange failed.';
-      console.error('  [oauth] Token exchange error:', errMsg);
+      console.error('  [oauth] Token exchange failed');
       finalizeSession(state, {
         status: 'error',
-        error: errMsg,
+        error: 'Token exchange failed.',
       });
       res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
-      res.end('Claude sign-in failed. You can close this tab and try again.\n\n' + errMsg);
+      res.end('Claude sign-in failed. You can close this tab and try again.');
     }
   });
 


### PR DESCRIPTION
## Summary
- Callback log no longer includes `req.url` (contained `code` + `state` params)
- Token exchange errors no longer include provider response body
- Browser-visible error responses use generic messages only
- Remaining log lines (`Callback received`, `listening on port`, `timed out`) are safe

## Test plan
- [x] `npm test` — 275 tests pass
- [ ] Manual: trigger OAuth flow, verify logs contain no `code=` or `state=` values

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)