### PR TITLE
ci: auto-merge Dependabot + Slack failure alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,12 +8,15 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - dependencies
+      - automerge
     commit-message:
       prefix: "deps:"
+    # Block ALL major version bumps — the tailwindcss 3→4 auto-merge
+    # caused a multi-day Electron CSS regression. Major upgrades require
+    # planned migration, not auto-PRs.
     ignore:
-      - dependency-name: "tailwindcss"
+      - dependency-name: "*"
         update-types: ["version-update:semver-major"]
-      - dependency-name: "@tailwindcss/*"
 
   - package-ecosystem: github-actions
     directory: /
@@ -22,5 +25,6 @@ updates:
       day: monday
     labels:
       - ci
+      - automerge
     commit-message:
       prefix: "ci:"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,23 @@ jobs:
           pwsh -Command "Get-Content scripts/install.ps1 | Out-Null" 2>/dev/null || true
           grep -q "tfournet" scripts/install.sh || (echo "ERROR: install.sh missing repo reference" && exit 1)
           grep -q "tfournet" scripts/install.ps1 || (echo "ERROR: install.ps1 missing repo reference" && exit 1)
+
+      - name: Notify Slack on failure (main only)
+        if: failure() && github.ref == 'refs/heads/main'
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "DeckWing CI failed on main",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":red_circle: *DeckWing CI failed on main*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
+                  }
+                }
+              ]
+            }

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,18 @@
+name: Auto-merge Dependabot
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Auto-merge Dependabot PRs after CI passes (patch/minor only — major bumps are blocked)
- Slack notification to #proj-deckwing when CI fails on main
- Broadened Dependabot ignore from just Tailwind to ALL major version bumps

## Setup required after merge
1. **Enable auto-merge**: Settings → General → Pull Requests → check "Allow auto-merge"
2. **Add Slack webhook**: Settings → Secrets → Actions → add `SLACK_WEBHOOK_URL` (create an incoming webhook in Slack for #proj-deckwing)

## Test plan
- [ ] Dependabot patch/minor PRs auto-merge after CI passes
- [ ] Dependabot major version PRs are not created
- [ ] CI failure on main posts to #proj-deckwing Slack channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)