### PR TITLE
feat: show thinking status while Deckster generates

### DIFF
--- a/e2e/mocks.js
+++ b/e2e/mocks.js
@@ -102,13 +102,26 @@ export async function mockAPIs(page, { authenticated = true, chatMode = 'reply' 
     });
   });
 
-  // Chat endpoint
+  // Chat endpoint (non-streaming fallback)
   await page.route('**/api/chat', (route) => {
+    if (route.request().url().includes('/chat/stream') || route.request().url().includes('/chat/session') || route.request().url().includes('/chat/reset')) return route.fallback();
     const body = chatMode === 'create' ? MOCK_CHAT_RESPONSE : MOCK_CHAT_REPLY;
     route.fulfill({
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify(body),
+    });
+  });
+
+  // Chat streaming endpoint (SSE format)
+  await page.route('**/api/chat/stream', (route) => {
+    const body = chatMode === 'create' ? MOCK_CHAT_RESPONSE : MOCK_CHAT_REPLY;
+    const sseData = `data: ${JSON.stringify({ type: 'result', reply: body.reply, action: body.action })}\n\n`;
+    route.fulfill({
+      status: 200,
+      contentType: 'text/event-stream',
+      headers: { 'Cache-Control': 'no-cache', 'Connection': 'keep-alive' },
+      body: sseData,
     });
   });
 

--- a/server/ai/chat-engine.js
+++ b/server/ai/chat-engine.js
@@ -36,6 +36,9 @@ function findGitBash() {
 }
 
 const MAX_TOKENS = 8192;
+const THINKING_MAX_TOKENS = 16384;
+const THINKING_BUDGET = 4096;
+const THINKING_MODELS = new Set(['sonnet', 'opus']);
 
 // Determine auth mode at startup
 const HAS_API_KEY = !!process.env.ANTHROPIC_API_KEY;
@@ -233,6 +236,58 @@ async function callDirectAPI(messages, model = DEFAULT_MODEL) {
 }
 
 /**
+ * Extract a short status line from accumulated thinking text.
+ * Takes the last complete sentence, capped at 100 chars.
+ */
+function extractThinkingStatus(thinkingText) {
+  const sentences = thinkingText
+    .split(/(?<=[.!?:\n])\s+/)
+    .map(s => s.trim())
+    .filter(s => s.length > 10);
+  if (sentences.length === 0) return null;
+  const latest = sentences[sentences.length - 1].replace(/\n/g, ' ');
+  return latest.length > 100 ? latest.substring(0, 97) + '...' : latest;
+}
+
+/**
+ * Call Claude via direct API with streaming + extended thinking.
+ * Calls onThinking(statusText) as thinking progresses.
+ */
+async function callDirectAPIStreaming(messages, model, onThinking) {
+  const stream = directClient.messages.stream({
+    model: resolveModelId(model),
+    max_tokens: THINKING_MAX_TOKENS,
+    thinking: { type: 'enabled', budget_tokens: THINKING_BUDGET },
+    system: SYSTEM_PROMPT,
+    messages,
+  });
+
+  let thinkingText = '';
+  let lastStatusTime = 0;
+
+  stream.on('thinking', (chunk) => {
+    thinkingText += chunk;
+    const now = Date.now();
+    // Debounce: update at most once per second
+    if (now - lastStatusTime >= 1000) {
+      lastStatusTime = now;
+      const status = extractThinkingStatus(thinkingText);
+      if (status) onThinking(status);
+    }
+  });
+
+  const finalMessage = await stream.finalMessage();
+
+  // Send one last status update from complete thinking
+  const finalStatus = extractThinkingStatus(thinkingText);
+  if (finalStatus) onThinking(finalStatus);
+
+  const textBlock = finalMessage.content.find(b => b.type === 'text');
+  if (!textBlock?.text) throw new Error('Claude returned an empty response');
+  return textBlock.text;
+}
+
+/**
  * Call Claude via Agent SDK (uses local Claude Code binary with its own auth).
  */
 async function callAgentSDK(messages, model = DEFAULT_MODEL) {
@@ -281,7 +336,7 @@ async function callAgentSDK(messages, model = DEFAULT_MODEL) {
 /**
  * Send a message to Claude and return the parsed response.
  */
-export async function chat({ sessionId, message, deck, currentSlideIndex, model }) {
+export async function chat({ sessionId, message, deck, currentSlideIndex, model, onThinking }) {
   const session = getSession(sessionId);
   if (!session) {
     throw new Error('Invalid or expired session. Please start a new chat.');
@@ -307,9 +362,14 @@ export async function chat({ sessionId, message, deck, currentSlideIndex, model 
         throw new Error('Not authenticated. Please sign in with Claude first.');
       }
     }
-    rawResponse = directClient
-      ? await callDirectAPI(session.messages, selectedModel)
-      : await callAgentSDK(session.messages, selectedModel);
+    const useThinking = directClient && onThinking && THINKING_MODELS.has(selectedModel);
+    if (useThinking) {
+      rawResponse = await callDirectAPIStreaming(session.messages, selectedModel, onThinking);
+    } else if (directClient) {
+      rawResponse = await callDirectAPI(session.messages, selectedModel);
+    } else {
+      rawResponse = await callAgentSDK(session.messages, selectedModel);
+    }
   } catch (apiError) {
     session.messages.pop();
     throw new Error(`Claude API call failed: ${apiError.message}`);

--- a/server/app.js
+++ b/server/app.js
@@ -242,6 +242,53 @@ app.post('/api/chat', async (req, res) => {
   }
 });
 
+// Streaming chat endpoint — SSE with thinking status updates
+app.post('/api/chat/stream', async (req, res) => {
+  const { message, deck, currentSlideIndex, sessionId, model } = req.body;
+
+  if (!message || typeof message !== 'string' || message.trim() === '') {
+    return res.status(400).json({ error: 'message is required' });
+  }
+
+  if (!sessionId || typeof sessionId !== 'string') {
+    return res.status(400).json({ error: 'sessionId is required' });
+  }
+
+  if (!checkRateLimit(sessionId)) {
+    return res.status(429).json({ error: 'Too many requests' });
+  }
+
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.flushHeaders();
+
+  try {
+    const result = await chat({
+      sessionId,
+      message: message.trim(),
+      deck: deck == null ? null : deck,
+      currentSlideIndex: Number.isFinite(currentSlideIndex) && currentSlideIndex >= 0
+        ? Math.floor(currentSlideIndex)
+        : 0,
+      model,
+      onThinking: (status) => {
+        res.write(`data: ${JSON.stringify({ type: 'thinking', status })}\n\n`);
+      },
+    });
+
+    res.write(`data: ${JSON.stringify({ type: 'result', reply: result.reply, action: result.action })}\n\n`);
+  } catch (err) {
+    console.error('  [chat stream error]', err.message);
+    const reply = err.message.includes('Invalid or expired session')
+      ? err.message
+      : 'Something went wrong on my end. Please try again.';
+    res.write(`data: ${JSON.stringify({ type: 'error', error: reply })}\n\n`);
+  }
+
+  res.end();
+});
+
 // Reset conversation history for a session
 app.post('/api/chat/reset', (req, res) => {
   const { sessionId } = req.body;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -37,7 +37,7 @@ function MainLayout() {
     applyAction,
   } = useDeckState();
   const { exporting, exportType, exportError, handleExportPDF, handleExportPPTX, handleExportHTML, handleExportDeckwing } = useExport({ deck });
-  const { messages, isLoading, sendMessage, resetChat } = useChat({ deck, onAction: applyAction, model: selectedModel, currentSlideIndex });
+  const { messages, isLoading, thinkingStatus, sendMessage, resetChat } = useChat({ deck, onAction: applyAction, model: selectedModel, currentSlideIndex });
 
   // Persist model selection
   useEffect(() => {
@@ -174,6 +174,7 @@ function MainLayout() {
           <ChatPanel
             messages={messages}
             isLoading={isLoading}
+            thinkingStatus={thinkingStatus}
             onSendMessage={sendMessage}
             onResetChat={resetChat}
             onClose={() => setChatOpen(false)}

--- a/src/components/chat/ChatMessage.jsx
+++ b/src/components/chat/ChatMessage.jsx
@@ -62,8 +62,9 @@ function describeAction(action) {
 
 /**
  * Animated typing indicator shown while the AI is processing.
+ * Shows a thinking status line when available, bouncing dots otherwise.
  */
-export function TypingIndicator() {
+export function TypingIndicator({ thinkingStatus }) {
   return (
     <div className="flex items-start gap-2 mb-3">
       {/* Teal accent bar */}
@@ -74,19 +75,25 @@ export function TypingIndicator() {
           <Bot size={11} className="text-bot-teal-400 shrink-0" />
           <span className="text-cloud-gray-500 text-xs font-medium">Deckster</span>
         </div>
-        <div className="bg-ops-indigo-800/60 border border-ops-indigo-600/30 rounded-lg px-3 py-2.5 inline-flex items-center gap-1">
-          <span
-            className="w-1.5 h-1.5 rounded-full bg-bot-teal-400/70 animate-bounce"
-            style={{ animationDelay: '0ms', animationDuration: '1s' }}
-          />
-          <span
-            className="w-1.5 h-1.5 rounded-full bg-bot-teal-400/70 animate-bounce"
-            style={{ animationDelay: '150ms', animationDuration: '1s' }}
-          />
-          <span
-            className="w-1.5 h-1.5 rounded-full bg-bot-teal-400/70 animate-bounce"
-            style={{ animationDelay: '300ms', animationDuration: '1s' }}
-          />
+        <div className="bg-ops-indigo-800/60 border border-ops-indigo-600/30 rounded-lg px-3 py-2.5">
+          {thinkingStatus ? (
+            <p className="text-cloud-gray-400 text-xs italic leading-relaxed">{thinkingStatus}</p>
+          ) : (
+            <div className="inline-flex items-center gap-1">
+              <span
+                className="w-1.5 h-1.5 rounded-full bg-bot-teal-400/70 animate-bounce"
+                style={{ animationDelay: '0ms', animationDuration: '1s' }}
+              />
+              <span
+                className="w-1.5 h-1.5 rounded-full bg-bot-teal-400/70 animate-bounce"
+                style={{ animationDelay: '150ms', animationDuration: '1s' }}
+              />
+              <span
+                className="w-1.5 h-1.5 rounded-full bg-bot-teal-400/70 animate-bounce"
+                style={{ animationDelay: '300ms', animationDuration: '1s' }}
+              />
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/chat/ChatPanel.jsx
+++ b/src/components/chat/ChatPanel.jsx
@@ -17,7 +17,7 @@ import { ChatMessage, TypingIndicator } from './ChatMessage';
  * @param {function} props.onResetChat - Called to reset conversation
  * @param {function} props.onClose - Called when close button clicked
  */
-export function ChatPanel({ messages, isLoading, onSendMessage, onResetChat, onClose, models, selectedModel, onModelChange }) {
+export function ChatPanel({ messages, isLoading, thinkingStatus, onSendMessage, onResetChat, onClose, models, selectedModel, onModelChange }) {
   const [inputValue, setInputValue] = useState('');
   const messagesEndRef = useRef(null);
   const inputRef = useRef(null);
@@ -145,7 +145,7 @@ export function ChatPanel({ messages, isLoading, onSendMessage, onResetChat, onC
                 onSelectOption={(value) => onSendMessage(value)}
               />
             ))}
-            {isLoading && <TypingIndicator />}
+            {isLoading && <TypingIndicator thinkingStatus={thinkingStatus} />}
             <div ref={messagesEndRef} />
           </>
         )}

--- a/src/hooks/useChat.js
+++ b/src/hooks/useChat.js
@@ -27,6 +27,7 @@ async function fetchSessionId() {
 export function useChat({ deck, onAction, model, currentSlideIndex }) {
   const [messages, setMessages] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [thinkingStatus, setThinkingStatus] = useState(null);
   const sessionIdRef = useRef(null);
 
   useEffect(() => {
@@ -46,9 +47,10 @@ export function useChat({ deck, onAction, model, currentSlideIndex }) {
 
     setMessages(prev => [...prev, userMsg]);
     setIsLoading(true);
+    setThinkingStatus(null);
 
     try {
-      const response = await fetch('/api/chat', {
+      const response = await fetch('/api/chat/stream', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -64,26 +66,60 @@ export function useChat({ deck, onAction, model, currentSlideIndex }) {
         throw new Error(`Server error: ${response.status}`);
       }
 
-      const data = await response.json();
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+      let result = null;
 
-      const assistantMsg = {
-        id: generateId(),
-        role: 'assistant',
-        content: data.reply || '',
-        action: data.action || null,
-        timestamp: new Date(),
-      };
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
 
-      setMessages(prev => [...prev, assistantMsg]);
+        buffer += decoder.decode(value, { stream: true });
+        const parts = buffer.split('\n\n');
+        buffer = parts.pop();
 
-      if (data.action && onAction) {
-        onAction(data.action);
+        for (const part of parts) {
+          const line = part.trim();
+          if (!line.startsWith('data: ')) continue;
+          try {
+            const data = JSON.parse(line.slice(6));
+            if (data.type === 'thinking') {
+              setThinkingStatus(data.status);
+            } else if (data.type === 'result') {
+              result = data;
+            } else if (data.type === 'error') {
+              throw new Error(data.error);
+            }
+          } catch (parseErr) {
+            if (parseErr.message && !parseErr.message.includes('JSON')) throw parseErr;
+          }
+        }
+      }
+
+      setThinkingStatus(null);
+
+      if (result) {
+        const assistantMsg = {
+          id: generateId(),
+          role: 'assistant',
+          content: result.reply || '',
+          action: result.action || null,
+          timestamp: new Date(),
+        };
+
+        setMessages(prev => [...prev, assistantMsg]);
+
+        if (result.action && onAction) {
+          onAction(result.action);
+        }
       }
     } catch (err) {
+      setThinkingStatus(null);
       const errorMsg = {
         id: generateId(),
         role: 'assistant',
-        content: 'Something went wrong. Please try again.',
+        content: err.message || 'Something went wrong. Please try again.',
         action: null,
         timestamp: new Date(),
         isError: true,
@@ -91,6 +127,7 @@ export function useChat({ deck, onAction, model, currentSlideIndex }) {
       setMessages(prev => [...prev, errorMsg]);
     } finally {
       setIsLoading(false);
+      setThinkingStatus(null);
     }
   }, [currentSlideIndex, deck, isLoading, model, onAction]);
 
@@ -119,6 +156,7 @@ export function useChat({ deck, onAction, model, currentSlideIndex }) {
   return {
     messages,
     isLoading,
+    thinkingStatus,
     sendMessage,
     resetChat,
     sessionId: sessionIdRef.current,


### PR DESCRIPTION
## Summary
- Adds streaming extended thinking so users see what Deckster is planning instead of bouncing dots
- New `/api/chat/stream` SSE endpoint streams thinking status updates + final result
- TypingIndicator shows a rolling one-line summary like *"Planning 4 slides with automation metrics..."*
- Only activates for Sonnet/Opus via direct API (they support extended thinking)
- Haiku and Agent SDK paths fall back gracefully to bouncing dots

## Changes
- `server/ai/chat-engine.js` — `callDirectAPIStreaming()` with extended thinking, `extractThinkingStatus()` for summary extraction, `onThinking` callback in `chat()`
- `server/app.js` — `POST /api/chat/stream` SSE endpoint
- `src/hooks/useChat.js` — SSE stream consumer with `thinkingStatus` state
- `src/components/chat/ChatMessage.jsx` — `TypingIndicator` shows status text
- `src/App.jsx`, `ChatPanel.jsx` — thread `thinkingStatus` through

## Test plan
- [x] `npm test` — all 314 tests pass
- [x] `npm run build` — succeeds
- [x] SSE endpoint returns correct event format
- [ ] Manual test: send a message with Sonnet, verify thinking status appears
- [ ] Manual test: send with Haiku, verify graceful fallback to dots

🤖 Generated with [Claude Code](https://claude.com/claude-code)