### PR TITLE
fix: refocus chat input after AI response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3629,9 +3629,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
+      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/components/chat/ChatPanel.jsx
+++ b/src/components/chat/ChatPanel.jsx
@@ -30,6 +30,13 @@ export function ChatPanel({ messages, isLoading, thinkingStatus, onSendMessage, 
     }
   }, [messages, isLoading]);
 
+  // Refocus input when loading finishes (disabled textarea loses focus)
+  useEffect(() => {
+    if (!isLoading) {
+      inputRef.current?.focus();
+    }
+  }, [isLoading]);
+
   const handleSend = useCallback(() => {
     const trimmed = inputValue.trim();
     if (!trimmed || isLoading) return;


### PR DESCRIPTION
## Summary
The chat textarea loses focus after submitting because `disabled={isLoading}` drops focus when the input is disabled. Added a `useEffect` that refocuses when loading finishes.

## Test plan
- [x] 314 unit tests pass
- [x] 11 e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)