### PR TITLE
security: reduce OAuth scopes to least privilege

### DIFF
--- a/server/ai/claude-oauth.js
+++ b/server/ai/claude-oauth.js
@@ -9,12 +9,9 @@ const AUTHORIZE_URL = 'https://claude.com/cai/oauth/authorize';
 const TOKEN_URL = 'https://platform.claude.com/v1/oauth/token';
 const SUCCESS_URL = 'https://platform.claude.com/oauth/code/success?app=claude-code';
 const SCOPES = [
-  'org:create_api_key',
   'user:profile',
   'user:inference',
   'user:sessions:claude_code',
-  'user:mcp_servers',
-  'user:file_upload',
 ].join(' ');
 const CALLBACK_HOST = 'localhost';
 const CALLBACK_PATH = '/callback';


### PR DESCRIPTION
## Summary

- Removes three unnecessary OAuth scopes from Claude OAuth flow: `org:create_api_key`, `user:mcp_servers`, and `user:file_upload`
- DeckWing only needs `user:profile` (identify user), `user:inference` (generate responses), and `user:sessions:claude_code` (SDK auth)
- Follows principle of least privilege to reduce attack surface

Closes #11

## Test plan

- [x] `npm test` -- all 314 unit tests pass
- [x] `npx playwright test` -- all 11 e2e tests pass
- [ ] Verify OAuth login flow still works end-to-end in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)