### PR TITLE
ci: enable Electron auto-update

### DIFF
--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -38,22 +38,7 @@ jobs:
       - name: Build frontend
         run: npm run build
 
-      - name: Build Electron package
-        run: npm run electron:build -- ${{ matrix.args }} --publish never
-
-      - name: Generate checksums
-        run: |
-          cd electron-dist
-          sha256sum DeckWing-Setup.exe DeckWing*.dmg DeckWing.AppImage 2>/dev/null | tee ELECTRON-SHA256SUMS.txt || true
-        shell: bash
-
-      - name: Upload Electron artifacts to GitHub Release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
-        with:
-          generate_release_notes: false
-          files: |
-            electron-dist/DeckWing-Setup.exe
-            electron-dist/DeckWing.dmg
-            electron-dist/DeckWing-*.dmg
-            electron-dist/DeckWing.AppImage
-            electron-dist/ELECTRON-SHA256SUMS.txt
+      - name: Build and publish Electron package
+        run: npm run electron:build -- ${{ matrix.args }} --publish always
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Changes `--publish never` to `--publish always` in the Electron Release workflow so electron-builder uploads the `latest.yml` metadata files that `electron-updater` needs to detect new versions.

**Before:** Installers were attached to GitHub Releases but no `latest.yml` — the auto-updater got 404s and silently failed.

**After:** electron-builder handles the full upload: installers + `latest.yml` / `latest-mac.yml` / `latest-linux.yml`. The separate checksum/softprops steps are removed since electron-builder does it all.

## Test plan
- [ ] Tag a release and verify the workflow uploads `latest.yml` alongside installers
- [ ] Install the previous version, launch, verify update prompt appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)